### PR TITLE
agent-docs: parameterize migration command and args; default to /app/…

### DIFF
--- a/agent-docs/Chart.yaml
+++ b/agent-docs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-docs-server
 description: Multi-Type Documentation Server with AI-Powered Semantic Search
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 
 keywords:

--- a/agent-docs/templates/migrations-job.yaml
+++ b/agent-docs/templates/migrations-job.yaml
@@ -31,8 +31,8 @@ spec:
         - name: migrate
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/usr/local/bin/http_server"]
-          args: ["--migrate-only"]
+          command: {{ toYaml .Values.migrations.command | nindent 12 }}
+          args: {{ toYaml .Values.migrations.args | nindent 12 }}
           env:
             {{- if .Values.secret.existingSecret }}
             - name: DATABASE_URL

--- a/agent-docs/values.yaml
+++ b/agent-docs/values.yaml
@@ -79,6 +79,10 @@ migrations:
   enabled: true
   backoffLimit: 3
   activeDeadlineSeconds: 7200
+  # Command and args used for the migration job
+  # Defaults run the server binary in migration-only mode from the runtime image
+  command: ["/app/http_server"]
+  args: ["--migrate-only"]
   resources:
     requests:
       cpu: 250m


### PR DESCRIPTION
…http_server --migrate-only; bump chart to 0.1.1