### PR TITLE
fix: Always set OPENAI_API_KEY env var to maintain backward compatibi…

### DIFF
--- a/agent-docs/templates/deployment.yaml
+++ b/agent-docs/templates/deployment.yaml
@@ -56,10 +56,8 @@ spec:
             {{- else }}
             - name: DATABASE_URL
               value: {{ required "DATABASE_URL must be set" .Values.env.DATABASE_URL | quote }}
-            {{- if .Values.env.OPENAI_API_KEY }}
             - name: OPENAI_API_KEY
               value: {{ .Values.env.OPENAI_API_KEY | quote }}
-            {{- end }}
             {{- end }}
             - name: RUST_LOG
               value: {{ .Values.env.RUST_LOG | quote }}


### PR DESCRIPTION
…lity

- Remove conditional check that only set OPENAI_API_KEY when truthy
- Always set the environment variable, allowing empty values
- Fixes Bugbot error about inconsistent environment variable behavior
- Maintains compatibility for applications expecting the var to always exist